### PR TITLE
Changes the Admin DateTime field to use a :short option

### DIFF
--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -17,5 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= l field.data %>
+  <%= field.data.to_formatted_s(:short) %>
 <% end %>


### PR DESCRIPTION
instead of using the Action::View helper. :short option shows a more readable date string. 

Date shows no longer shows year, seconds, or timezone.
