### PR TITLE
Location cant be blank

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -67,6 +67,10 @@ module Admin
           notice: translate_with_resource("create.success"),
         )
       else
+        flash[:alert] = resource.errors.full_messages.join(', ')
+        resource = resource_class.new
+        resource.open_schedule = OpenSchedule.new
+        resource.open_schedule.add_9_to_5
         render :new, locals: {
           page: Administrate::Page::Form.new(dashboard, resource),
         }

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -15,6 +15,7 @@ class Location < ActiveRecord::Base
   alias_attribute :lat, :latitude
   alias_attribute :lng, :longitude
 
+  validates_presence_of :name
   # admins explicitly having access to this Location instance
   # excluding superadmin
   def admins

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Location, type: :model do
   describe '#amenities' do
     it 'can be an array' do
       location = Location.new
+      location.name = 'Conference Room'
       location.amenity_list = [ 'Projector', 'Conference Phone' ]
       location.save
       expect( location.amenities.count ).to eq( 2 )

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Location, type: :model do
     it 'has nooks and reservations' do
       expect(location).to respond_to :nooks, :reservations
     end
+
+    it 'must have a name' do
+      location.save
+      expect(location.errors.full_messages).to include("Name can't be blank")
+    end
   end
 
   describe '#set_defaults' do


### PR DESCRIPTION
Hi @shubhpatel108

I believe this is what the issue wanted to accomplish. The admin can no longer create a location without a name. A note about the admin/locations_controller change: 

Lines 71 through 73 were added because the resource would not have an `OpenSchedule` otherwise. Without it, there would be a failure down the stack in the `OpenAtField#days` method where `data` would be nil. 

Otherwise this was a simple fix to add a validation to the model and flash the alert when the resource fails to be saved, adding a spec, and updating a former spec to now include a name.

I believe this meets the indented functionality, please look it over and let me know. 
Best, David

Closes #130 

