### PR TITLE
Fixed unscaled image in admin view of nooks

### DIFF
--- a/app/views/admin/nooks/show.html.erb
+++ b/app/views/admin/nooks/show.html.erb
@@ -1,0 +1,42 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { page.page_title } %>
+
+<header class="header">
+  <h1 class="header-heading"><%= content_for(:title) %></h1>
+  <div class="header-actions">
+    <%= link_to(
+      "Edit",
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) %>
+  </div>
+</header>
+
+<dl>
+  <% page.attributes.each do |attribute| %>
+    <dt class="attribute-label"><%= attribute.name.titleize %></dt>
+    <% if attribute.name == 'photos'%>
+      <%= image_tag "#{attribute.data.first}", style: 'height: 30%; width: 30%;'%>
+    <% else %>
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+        ><%= render_field attribute %></dd>
+    <%end%>
+  <% end %>
+</dl>


### PR DESCRIPTION
Added a max height and width of 30% for nooks photos in admin views. Fixes issue #202 .