### PR TITLE
Disable overlapping reservation

### DIFF
--- a/app/controllers/admin/nooks_controller.rb
+++ b/app/controllers/admin/nooks_controller.rb
@@ -96,7 +96,7 @@ module Admin
       @reservation = Reservation.where(id: reservation_id).first
       @available = nil
       unless @reservation.nil?
-        @available = @reservation.nook.available_for?(@reservation.start..@reservation.end)
+        @available = @reservation.nook.available_for?(@reservation.start..@reservation.end,@reservation)
       end
       render :js, template: 'admin/nooks/availability'
     end

--- a/app/models/nook.rb
+++ b/app/models/nook.rb
@@ -41,8 +41,8 @@ class Nook < ActiveRecord::Base
     available
   end
 
-  def available_for?(time_range)
-    available = bookable && reservations.overlapping_with(time_range).empty?
+  def available_for?(time_range,res=nil)
+    available = bookable && reservations.overlapping_with(time_range,res).empty?
     available &&= location.open_for_range?(time_range) if location.open_schedule
     available &&= open_for_range?(time_range) if open_schedule
     available # I don't think this line is necessary, but not sure yet.

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -7,6 +7,7 @@ class Reservation < ActiveRecord::Base
 
   scope :is_public, -> { where(public: true) }
   scope :confirmed, -> { where(status: Reservation::Status::CONFIRMED) }
+  scope :possible_conflict, ->(res=nil) { where.not(status: Reservation::Status::HIDEABLE, id: res) }
 
   acts_as_taggable_on :remarks
 
@@ -20,6 +21,7 @@ class Reservation < ActiveRecord::Base
       'Awaiting review', 'Rejected', 'Confirmed', 'Canceled'
     CANCELABLE = [PENDING, CONFIRMED]
     MODIFIABLE = [PENDING]
+    HIDEABLE = [REJECTED, CANCELED]
   end
 
   STATUSES = Status.constants.map{|s| Status.const_get(s)}.flatten.uniq
@@ -42,7 +44,7 @@ class Reservation < ActiveRecord::Base
   validates_numericality_of :priority, only_integer: true,
     greater_than_or_equal_to: 0
   validate :minimum_length, :maximum_length
-
+  validate :available
   after_initialize :set_defaults
 
   def time_range
@@ -88,6 +90,10 @@ class Reservation < ActiveRecord::Base
     (Status::MODIFIABLE.include? status) && ((self.start.to_i-Time.now.to_i) > (self.nook.modifiable_before*3600))
   end
 
+  def available
+    errors.add(:nook_id, "is not available for given time duration") unless self.nook.available_for?(self.start_time..self.end_time,self)
+  end
+
   def self.confirmed(reservations=nil)
     return where(status: Status::CONFIRMED) if reservations.nil?
     reservations.where(status: Status::CONFIRMED)
@@ -109,8 +115,8 @@ class Reservation < ActiveRecord::Base
                     'tsrange(?, ?)', time_range.begin, time_range.end)
   end
 
-  def self.overlapping_with(time_range)
-    confirmed.where('tsrange("reservations"."start_time", "reservations"."end_time") && ' +
+  def self.overlapping_with(time_range,res=nil)
+    possible_conflict(res).where('tsrange("reservations"."start_time", "reservations"."end_time") && ' +
                     'tsrange(?, ?)', time_range.begin, time_range.end)
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,24 @@
 FactoryGirl.define do
+  sequence :start_time do |n|
+    d = (Time.now + 48.hours).next_week
+    start_time = d.change(hour: 9) + (n % 8).hour
+    if start_time < (d+1.day).change(hour:9) or start_time > d.change(hour: 16, min: 29)
+      # puts start_time
+      next_date = (d + (n % 7).days)
+      if 0 < next_date.wday and next_date.wday < 6
+        d = next_date
+      else
+        d = next_date.next_week
+      end
+      start_time = d.change(hour: 9) + (n % 7).hour
+    # else
+    #   puts start_time, "n", n
+    end
+    start_time
+  end
+
   factory :nook do
-    sequence(:name, 'Nook 1')
+    sequence(:name) { |n| "Nice nook #{n}" }
     description "It's a nice nook."
     location
     bookable true
@@ -31,9 +49,8 @@ FactoryGirl.define do
     sequence(:name) { |n| "Test Reservation #{n}" }
     association :requester, factory: :confirmed_user
     add_attribute('public', true)
-    start 49.hour.from_now
-    add_attribute('end', 50.hour.from_now)
-
+    start_time
+    end_time { start_time + 29.minutes}
     factory :confirmed_reservation do
       status Reservation::Status::CONFIRMED
     end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe Reservation, type: :model do
     @reservation.start= 47.hours.from_now
     expect(@reservation.cancelable?).to eq(false)
   end
+
+  it "should not allow overlapping reservation request" do
+    overlap = create(:reservation, nook: @reservation.nook) #.new({title: "new Reservation"})
+    overlap.start = @reservation.start + 10.minutes
+    overlap.end = @reservation.end + 10.minutes
+    overlap.valid?
+    expect(overlap.errors[:nook_id]).to include("is not available for given time duration")
+    overlap.start = @reservation.start + 30.minutes
+    overlap.end = overlap.start + 29.minutes
+    overlap.valid?
+    expect(overlap.errors[:nook_id]).to_not include("is not available for given time duration")
+  end
 end


### PR DESCRIPTION
Look for potential overlaps in pending and confirmed reservations and raise validation errors. Fixes issue #65 